### PR TITLE
Fjerne logg-innslag i rapporter

### DIFF
--- a/inst/LokalIndikatorMaaned.Rmd
+++ b/inst/LokalIndikatorMaaned.Rmd
@@ -32,7 +32,7 @@ library(dplyr)
 
 ```
 
-```{r get data, warning = FALSE, message=TRUE}
+```{r get data, warning = FALSE, message = FALSE}
 
 if (rapbase::isRapContext()) {
   dat <- smerte::getRegDataIndikator(registryName = params$registryName,

--- a/inst/LokalTilsynsrapportMaaned.Rmd
+++ b/inst/LokalTilsynsrapportMaaned.Rmd
@@ -28,7 +28,7 @@ options(tinytex.verbose = TRUE)
 #FIX: Må det legges inn noe som avjgør lokasjon
 ```
 
-```{r get data, warning = TRUE, message=TRUE}
+```{r get data, warning = TRUE, message = FALSE}
 
 if (rapbase::isRapContext()) {
   dat <- smerte::getRegDataLokalTilsynsrapportMaaned(

--- a/inst/NasjonalIndikatorMaaned.Rmd
+++ b/inst/NasjonalIndikatorMaaned.Rmd
@@ -29,7 +29,7 @@ options(scipen = 1, digits = 2) #set to two decimal
 
 ```
 
-```{r get data, warning = FALSE, message=TRUE}
+```{r get data, warning = FALSE, message = FALSE}
 
 if (rapbase::isRapContext()) {
   dat <- smerte::getRegDataIndikator(registryName = params$registryName,


### PR DESCRIPTION
I enkelte rapporter var message satt til true under lasting av data. I nyere versjoner av rapbase logges det ved spørring til database. Disse logg-beskjedene dukkket da opp i rapportene.