### PR TITLE
Docker: mat inn secrets/repo + diverse

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,6 +28,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
 
     steps:
       - uses: actions/checkout@v6
@@ -35,6 +36,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,8 +6,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '0 21 * * 6' # run every Saturday at 21
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,11 +19,7 @@ jobs:
       IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
-      - name: R setup
-        uses: r-lib/actions/setup-r@v2
-      - name: Build package (tarball)
-        run: R CMD build .
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.3.0
         with:
@@ -38,7 +32,6 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=schedule,pattern=weekly
             type=semver,pattern={{major}}.{{minor}}.{{patch}}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -56,4 +49,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          build-args: GH_PAT=${{ secrets.GITHUB_TOKEN }}
+          secrets: "github_pat=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/harbor.yaml
+++ b/.github/workflows/harbor.yaml
@@ -3,11 +3,9 @@ on:
   release:
     types: [published]
   push:
-    branches:
-        - main
+    branches: [ "main" ]
   pull_request:
-    branches:
-        - main
+    branches: [ "main" ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,18 +16,14 @@ jobs:
     name: Push Docker image to Harbor
     runs-on: ubuntu-latest
     env:
-        IMAGE_NAME: ${{ github.repository }}
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: "Dockerfile"
-      - name: R setup
-        uses: r-lib/actions/setup-r@v2
-      - name: Build package (tarball)
-        run: R CMD build .
       - name: Prepare tags
         id: docker_meta
         uses: docker/metadata-action@v6
@@ -54,5 +48,8 @@ jobs:
           file: ./Dockerfile
           tags: ${{ secrets.HARBOR_REGISTRY }}/${{ steps.docker_meta.outputs.tags }}
           push: ${{ github.event_name == 'release' }}
+          pull: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            "github_pat=${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,10 +17,13 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -16,7 +16,8 @@ jobs:
   test-coverage:
     runs-on: ubuntu-24.04
     env:
-      GITHUB_PAT: ${{ secrets.GH_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_COMPILE_AND_INSTALL_PACKAGES: never
       GITHUB_ACTIONS_RUN_DB_UNIT_TESTS: true
       MYSQL_HOST: "localhost"
       MYSQL_USER: "root"
@@ -26,6 +27,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 FROM rapporteket/base-r:main
 
-LABEL maintainer="Kevin Thon <kevin.otto.thon@helse-nord.no>"
-LABEL no.rapporteket.cd.enable="true"
-
-ARG GH_PAT
-ENV GITHUB_PAT=${GH_PAT}
-
 WORKDIR /app/R
 
-COPY *.tar.gz .
-
-RUN R -e "remotes::install_local(list.files(pattern = \"*.tar.gz\"))" \
-  && rm ./*.tar.gz \
+RUN --mount=type=secret,id=github_pat,env=GITHUB_PAT \
+    --mount=type=bind,source=.,target=/app/R/pkg \
+    R -e "remotes::install_local(path = './pkg')" \
   && R -e "remotes::install_github(\"Rapporteket/rapbase\", ref = \"main\")"
 
 EXPOSE 3838


### PR DESCRIPTION
- Matet inn secrets, slik at de ikke være synlig i bygg etterpå.
- Matet inn repo og bygde pakken inne i Dockerfile. Det betyr at det ikke lenger er nødvendig å bygge en tar.gz-fil utenfor før man bygger image. Da slipper man å sette opp R-miljø i action.
- Byttet i tillegg til GITHUB_TOKEN, som kun finnes midlertidig mens jobb kjører.
- Oppdatert også actions-jobber med diverse små-endringer. 
- Prøvd å gjøre jobbene kjappere ved å bruke ferdig-installerte pakker.
